### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,6 @@ datasource db {
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
     // If working with a local postgres instance, you may need to comment out the lines below if you're getting a null user error.
     directUrl         = env("POSTGRES_URL") // uses a direct connection
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 generator client {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.